### PR TITLE
fix: resolve CLI package peer dependency warnings

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@inquirer/prompts": "^7.0.0",
     "chalk": "^5.3.0",
     "commander": "^14.0.0",
     "cosmiconfig": "^9.0.0",
@@ -69,9 +70,6 @@
     "tsup": "^8.5.0",
     "typescript": "^5.3.0",
     "vitest": "^1.2.0"
-  },
-  "peerDependencies": {
-    "@inquirer/prompts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
   packages/cli:
     dependencies:
       '@inquirer/prompts':
-        specifier: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+        specifier: ^7.0.0
         version: 7.5.3(@types/node@20.19.2)
       chalk:
         specifier: ^5.3.0


### PR DESCRIPTION
## Summary

- Move @inquirer/prompts from peerDependencies to dependencies in CLI package
- Eliminates pnpm link warnings about unresolved peer dependencies
- Ensures consistent prompt functionality without external dependency management

## Changes Made

### CLI Package Dependencies
- **Moved @inquirer/prompts**: From peerDependencies to dependencies 
- **Version pinned**: Set to ^7.0.0 for consistency with web-ui package
- **Eliminated warnings**: No more peer dependency resolution warnings during linking

## Background

The CLI framework exports prompt utilities from @inquirer/prompts but marked it as a peer dependency. This caused warnings when linking the package because peer dependencies aren't automatically resolved in linked scenarios.

Moving it to regular dependencies ensures:
- Consistent prompt functionality across environments
- No setup burden for consuming projects
- Cleaner development experience

## Notes

The "no binaries" warning mentioned in the issue is expected and correct for CLI framework packages. @trailhead/cli provides tools for building CLIs rather than executable binaries themselves.

## Test Plan

- [x] Package builds successfully
- [x] pnpm link works without warnings
- [x] All existing tests pass
- [x] No breaking changes to public API