### PR TITLE
fix(web-ui): remove duplicate CLI options in install command tests

### DIFF
--- a/packages/web-ui/tests/src/cli/commands/install.test.ts
+++ b/packages/web-ui/tests/src/cli/commands/install.test.ts
@@ -24,10 +24,6 @@ function convertToCommanderJS<T>(cliCommand: CLICommand<T>): Command {
     }
   }
 
-  // Add base CLI options that are automatically added by @esteban-url/trailhead-cli
-  cmd.option('-v, --verbose', 'show detailed output', false);
-  cmd.option('--dry-run', 'preview mode - show what would be done without executing', false);
-
   return cmd;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   glob@<10: '>=11.0.0'
   inflight: npm:@void/noop@^1.0.0
 
+pnpmfileChecksum: sha256-DyO6yjXE0gQbyrSMkuOoJ8hdZjiZkprg72xLxUslCdg=
+
 importers:
 
   .:


### PR DESCRIPTION
## Summary
- Fixed duplicate CLI option conflict in install command tests
- Removed manual addition of --verbose and --dry-run options that were already defined in the command

## Test plan
- [x] All tests pass
- [x] No duplicate option conflicts
- [x] Install command tests work correctly