### PR TITLE
fix(web-ui): change dev:refresh to dev-refresh for command name validation

### DIFF
--- a/packages/web-ui/src/cli/commands/dev-refresh.ts
+++ b/packages/web-ui/src/cli/commands/dev-refresh.ts
@@ -108,11 +108,11 @@ const createRefreshPhases = (_options: DevRefreshOptions): CommandPhase<RefreshC
 // ============================================================================
 
 /**
- * Create dev:refresh command
+ * Create dev-refresh command
  */
 export const createDevRefreshCommand = () => {
   return createCommand<DevRefreshOptions>({
-    name: 'dev:refresh',
+    name: 'dev-refresh',
     description: '[Dev] Copy fresh Catalyst components with catalyst- prefix for development',
 
     options: [


### PR DESCRIPTION
## Summary

- Change command name from `dev:refresh` to `dev-refresh` to comply with CLI framework validation
- Update JSDoc comment to reflect the new command name

## Root Cause

The CLI framework validates command names using the regex `/^[a-zA-Z][a-zA-Z0-9-]*$/` which only allows alphanumeric characters and hyphens. The colon `:` in `dev:refresh` was causing validation failures in the "Test CLI Package" step.

## Test plan

- [x] Command builds successfully
- [x] Command name follows alphanumeric-with-hyphens convention
- [x] Updated documentation comments
- [x] Should resolve "Invalid command name format" error in CI

## Related

Fixes the CLI package test failure: "Invalid command name format 'dev:refresh'. Use alphanumeric characters and hyphens only"