### PR TITLE
fix(ci): resolve pnpm version mismatch and CLI verbose conflict

### DIFF
--- a/.github/workflows/cli-examples.yml
+++ b/.github/workflows/cli-examples.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 10.12.1
+          version: 10.12.4
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
@@ -85,7 +85,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 10.12.1
+          version: 10.12.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 10.12.1
+          version: 10.12.4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.12.1
+          version: 10.12.4
           run_install: false
 
       - name: Get pnpm store directory

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -201,8 +201,15 @@ export function createCLI(config: CLIConfig): CLI {
           }
         }
 
-        // Add verbose flag to all commands
-        cmd.option('-v, --verbose', 'show detailed output', false);
+        // Add verbose flag to all commands (only if not already defined)
+        const hasVerboseOption = command.options?.some(
+          (option) =>
+            option.flags?.includes('--verbose') || option.flags?.includes('-v'),
+        );
+
+        if (!hasVerboseOption) {
+          cmd.option('-v, --verbose', 'show detailed output', false);
+        }
 
         // Set up action handler
         cmd.action(async (...args: any[]) => {


### PR DESCRIPTION
## Summary
- Update all GitHub Actions workflows to use pnpm 10.12.4 to match package.json packageManager field
- Fix CLI framework verbose option conflict by checking for existing verbose flags before adding global one
- Add optional chaining to handle undefined flags property in TypeScript

## Test plan
- [x] CI workflows should run without pnpm version errors
- [x] CLI commands should work without verbose flag conflicts
- [x] TypeScript compilation should pass