### PR TITLE
ci: add workflow to cleanup PR caches automatically

### DIFF
--- a/.github/workflows/cleant-cache.yml
+++ b/.github/workflows/cleant-cache.yml
@@ -1,0 +1,29 @@
+name: Cleanup github runner caches on closed pull requests
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Cleanup
+        run: |
+          echo "Fetching list of cache keys"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge


### PR DESCRIPTION
## Summary

- Add GitHub Actions workflow to automatically cleanup caches when PRs are closed
- Helps prevent cache storage from accumulating over time

## Changes

- Added `.github/workflows/cleant-cache.yml` workflow
- Triggers on PR close events to clean up associated cache keys
- Uses GitHub CLI to fetch and delete PR-specific caches

## Benefits

- Reduces storage usage from accumulated build caches
- Automatic cleanup without manual intervention
- Scoped to individual PR branches for safety