### PR TITLE
fix(web-ui): improve theme registry error handling and logging

### DIFF
--- a/packages/cli/examples/__tests__/advanced-cli.test.ts
+++ b/packages/cli/examples/__tests__/advanced-cli.test.ts
@@ -44,7 +44,7 @@ describe.skip('Advanced CLI Example Integration Tests', () => {
     // Clean up temporary directory
     try {
       await fs.rm(testDir, { recursive: true, force: true });
-    } catch (error) {
+    } catch {
       // Ignore cleanup errors
     }
   });
@@ -394,7 +394,7 @@ describe.skip('Advanced CLI Example Integration Tests', () => {
             'Failed to write file',
           );
         }
-      } catch (error) {
+      } catch {
         // Skip this test if we can't create read-only directory
         console.log(
           'Skipping permission test - unable to create read-only directory',
@@ -404,7 +404,7 @@ describe.skip('Advanced CLI Example Integration Tests', () => {
         try {
           await fs.chmod(readOnlyDir, 0o755);
           await fs.rmdir(readOnlyDir);
-        } catch (error) {
+        } catch {
           // Ignore cleanup errors
         }
       }

--- a/packages/cli/examples/__tests__/basic-cli.test.ts
+++ b/packages/cli/examples/__tests__/basic-cli.test.ts
@@ -3,7 +3,7 @@ import { execSync } from 'child_process';
 import { resolve } from 'path';
 
 // Mock process.exit to prevent test suite from exiting
-const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+const _mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
   throw new Error('process.exit called');
 });
 

--- a/packages/cli/examples/__tests__/error-scenarios.test.ts
+++ b/packages/cli/examples/__tests__/error-scenarios.test.ts
@@ -22,7 +22,7 @@ describe.skip('CLI Examples Error Scenarios', () => {
   afterAll(async () => {
     try {
       await fs.rm(testDir, { recursive: true, force: true });
-    } catch (error) {
+    } catch {
       // Ignore cleanup errors
     }
   });
@@ -135,7 +135,9 @@ describe.skip('CLI Examples Error Scenarios', () => {
             );
             expect(result).toBeDefined();
           } catch (error: any) {
-            expect.fail(`Should have succeeded with: ${args.join(' ')}`);
+            expect.fail(
+              `Should have succeeded with: ${args.join(' ')}, error: ${error.message}`,
+            );
           }
         } else {
           try {

--- a/packages/cli/examples/__tests__/interactive-cli.test.ts
+++ b/packages/cli/examples/__tests__/interactive-cli.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { execSync, spawn } from 'child_process';
+import { execSync } from 'child_process';
 import { resolve } from 'path';
-import {
-  runInteractiveTest,
-  createInteractiveTestHelper,
-} from '../../src/testing/interactive.js';
+import { createInteractiveTestHelper } from '../../src/testing/interactive.js';
 
 // Skip example CLI tests - they require @esteban-url/trailhead-cli to be published or dist files built
 // These tests execute actual CLI files that import from dist/index.js

--- a/packages/cli/examples/__tests__/performance.test.ts
+++ b/packages/cli/examples/__tests__/performance.test.ts
@@ -38,7 +38,7 @@ describe.skip('CLI Examples Performance Tests', () => {
     // Clean up test directory
     try {
       await fs.rm(testDir, { recursive: true, force: true });
-    } catch (_error) {
+    } catch {
       // Ignore cleanup errors
     }
 

--- a/packages/cli/examples/__tests__/performance.test.ts
+++ b/packages/cli/examples/__tests__/performance.test.ts
@@ -38,7 +38,7 @@ describe.skip('CLI Examples Performance Tests', () => {
     // Clean up test directory
     try {
       await fs.rm(testDir, { recursive: true, force: true });
-    } catch (error) {
+    } catch (_error) {
       // Ignore cleanup errors
     }
 

--- a/packages/cli/examples/__tests__/project-examples-deep.test.ts
+++ b/packages/cli/examples/__tests__/project-examples-deep.test.ts
@@ -21,7 +21,7 @@ describe.skip('Project Examples Deep Integration Tests', () => {
     // Clean up temporary directory
     try {
       await fs.rm(testDir, { recursive: true, force: true });
-    } catch (error) {
+    } catch {
       // Ignore cleanup errors
     }
   });

--- a/packages/cli/examples/__tests__/project-examples-smoke.test.ts
+++ b/packages/cli/examples/__tests__/project-examples-smoke.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { execSync } from 'child_process';
 import { resolve } from 'path';
 import { promises as fs } from 'fs';
@@ -11,7 +11,7 @@ describe.skip('Project Examples Smoke Tests', () => {
   const examplesDir = resolve(__dirname, '..');
 
   // Helper function to ensure dependencies are installed
-  async function ensureDependencies(projectPath: string) {
+  async function ensureDependencies(_projectPath: string) {
     // In the monorepo context, dependencies are hoisted by pnpm
     // The examples rely on the built CLI package, so we just need
     // to ensure the package is built
@@ -365,7 +365,8 @@ describe.skip('Project Examples Smoke Tests', () => {
           }
         } catch (error) {
           console.log(
-            `Project ${dir} not found or has issues - this might be expected`,
+            `Project ${dir} not found or has issues - this might be expected:`,
+            error,
           );
         }
       }
@@ -381,7 +382,8 @@ describe.skip('Project Examples Smoke Tests', () => {
         expect(tsconfig.compilerOptions).toBeDefined();
       } catch (error) {
         console.log(
-          'Examples tsconfig.json not found - this might be expected',
+          'Examples tsconfig.json not found - this might be expected:',
+          error,
         );
       }
     });

--- a/packages/cli/examples/advanced-cli.ts
+++ b/packages/cli/examples/advanced-cli.ts
@@ -6,7 +6,6 @@ import {
   match,
   tryCatch,
   tryCatchAsync,
-  chain,
   all,
 } from '@esteban-url/trailhead-cli/core';
 import {

--- a/packages/cli/examples/basic-cli.ts
+++ b/packages/cli/examples/basic-cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { createCLI, Ok, Err, isOk } from '@esteban-url/trailhead-cli';
+import { createCLI, Ok, Err } from '@esteban-url/trailhead-cli';
 import { createCommand } from '@esteban-url/trailhead-cli/command';
 
 // Example 1: Basic command with options

--- a/packages/cli/examples/cross-platform-cli/src/index.ts
+++ b/packages/cli/examples/cross-platform-cli/src/index.ts
@@ -4,12 +4,11 @@ import { createCLI } from '@esteban-url/trailhead-cli';
 import { createCommand } from '@esteban-url/trailhead-cli/command';
 import { Ok } from '@esteban-url/trailhead-cli';
 import { platform, homedir, tmpdir } from 'os';
-import { join } from 'path';
 
 const infoCommand = createCommand({
   name: 'info',
   description: 'Display system information',
-  action: async (options, context) => {
+  action: async (_options, _context) => {
     const info = {
       platform: platform(),
       homeDirectory: homedir(),

--- a/packages/cli/examples/interactive-cli.ts
+++ b/packages/cli/examples/interactive-cli.ts
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
-import { createCLI, Ok, Err } from '@esteban-url/trailhead-cli';
+import { createCLI, Ok } from '@esteban-url/trailhead-cli';
 import {
   createCommand,
   executeInteractive,
-  type CommandContext,
 } from '@esteban-url/trailhead-cli/command';
 import {
   prompt,

--- a/packages/cli/examples/todo-cli/src/index.ts
+++ b/packages/cli/examples/todo-cli/src/index.ts
@@ -61,7 +61,7 @@ const addCommand = createCommand({
 const listCommand = createCommand({
   name: 'list',
   description: 'List all todos',
-  action: async (options, context) => {
+  action: async (_options, _context) => {
     const fs = new FileSystem();
     const todos = await loadTodos(fs);
 

--- a/packages/cli/src/command/__tests__/patterns.test.ts
+++ b/packages/cli/src/command/__tests__/patterns.test.ts
@@ -332,7 +332,7 @@ describe('Command Patterns', () => {
       expect(result.success).toBe(false);
       expect(rollback1).toHaveBeenCalled();
       expect(mockContext.logger.error).toHaveBeenCalledWith(
-        'Failed to rollback: operation1',
+        'Failed to rollback: operation1: Error: Rollback failed',
       );
     });
 

--- a/packages/cli/src/command/patterns.ts
+++ b/packages/cli/src/command/patterns.ts
@@ -98,8 +98,10 @@ export async function executeFileSystemOperations<T>(
               try {
                 await completedOp.rollback();
                 context.logger.debug(`Rolled back: ${completedOp.name}`);
-              } catch (_error) {
-                context.logger.error(`Failed to rollback: ${completedOp.name}`);
+              } catch (error) {
+                context.logger.error(
+                  `Failed to rollback: ${completedOp.name}: ${error}`,
+                );
               }
             }
           }

--- a/packages/web-ui/src/components/theme/registry.ts
+++ b/packages/web-ui/src/components/theme/registry.ts
@@ -28,8 +28,8 @@ export const createThemeMap = (): ThemeMap => {
     try {
       const theme = getPresetTheme(name);
       themes.set(name, theme);
-    } catch (_error) {
-      // Silently skip failed preset themes
+    } catch (error) {
+      console.warn(`Failed to load preset theme "${name}":`, error);
     }
   }
 
@@ -79,6 +79,7 @@ export const getThemeNames = (themes: ThemeMap): string[] => {
 export const applyThemeToDocument = (themes: ThemeMap, name: string, isDark: boolean): void => {
   const theme = getTheme(themes, name);
   if (!theme) {
+    console.error(`Theme "${name}" is not registered`);
     return;
   }
   applyTheme(theme, isDark);

--- a/packages/web-ui/src/components/theme/theme-provider.tsx
+++ b/packages/web-ui/src/components/theme/theme-provider.tsx
@@ -97,6 +97,7 @@ export function useTheme(): ThemeContextValue {
     (name: string) => {
       // Validate theme exists
       if (!getTheme(themes, name)) {
+        console.error(`Theme "${name}" is not registered`);
         return;
       }
       // Set theme with current dark mode state


### PR DESCRIPTION
## Summary
- Replace silent error handling with console.warn for failed preset themes
- Add console.error for unregistered themes in applyThemeToDocument
- Improve debugging experience by providing visibility into theme loading issues

## Test plan
- [x] TypeScript compilation passes
- [x] Lint checks pass
- [x] All existing tests continue to pass
- [x] Theme registry error handling provides useful console output