### PR TITLE
docs: simplify CLAUDE.md by removing over-engineering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,17 +12,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Skip transitional phrases ("Let me...", "I'll help you...")
 - Be direct like a CLI response
 
-### Core Development Principles
+### Core Principles
 
-1. **Prefer libraries over custom implementations** - Use established libraries
-2. **Write easy to read code** - Clarity over cleverness, explicit over implicit
-3. **Always test new code** - Every feature/change must have HIGH-ROI tests
-4. **Follow functional programming principles** - Pure functions, immutable data
-5. **DRY** (Don't Repeat Yourself)
-6. **KISS** (Keep It Simple, Stupid)
-7. **YAGNI** (You Aren't Gonna Need It) - Avoid over-engineering
-8. **No legacy code** - Keep codebase clean and modern until v2.0
-9. **Do One Thing Well** - Every feature, function, and file should have a single, clearly defined purpose
+1. **Functional programming** - Pure functions, immutable data, composition over inheritance
+2. **High-ROI testing** - Test user interactions, business logic, integration; avoid low-ROI rendering tests
+3. **YAGNI + DRY + KISS** - Avoid over-engineering, eliminate duplication, keep it simple
+4. **One responsibility** - Every feature, function, and file does one thing well
+5. **Prefer libraries** - Use established solutions over custom implementations
 
 ### Development Discipline - MANDATORY WORKFLOW
 
@@ -65,18 +61,12 @@ git checkout -b feature/issue-123-specific-problem
 4. **Will this be used by >80% of users?** If no, don't include it
 5. **Can users add this themselves later?** If yes, leave it out
 
-**FORBIDDEN PATTERNS** (Immediate rejection):
+**ANTI-PATTERNS TO AVOID**:
 
-- ❌ "Future-proofing" without specific future requirements
-- ❌ Abstractions over abstractions (wrapper libraries)
-- ❌ Enterprise features for individual developers
-- ❌ Monitoring/observability for simple tools
-- ❌ "Best practices" that add complexity without clear benefit
-- ❌ Documentation frameworks for small projects
-- ❌ CI/CD optimizations for <5 contributors
-- ❌ Branches created from other branches (scope creep indicator)
-
-**CLAUDE MUST ACTIVELY RESIST** these requests and suggest simpler alternatives.
+- Future-proofing without specific requirements
+- Enterprise features for individual developers  
+- Over-abstraction and unnecessary complexity
+- Branch-on-branch (scope creep indicator)
 
 ### Testing Philosophy - High-ROI Tests
 
@@ -108,171 +98,11 @@ Focus on high-ROI (Return on Investment) tests:
 - Consider impact across packages when making changes
 - Test related packages when making cross-cutting changes
 
-### Context7 MCP Integration
+### Dependencies & Documentation
 
-**IMPORTANT**: Context7 provides access to up-to-date, version-specific documentation for eliminating outdated code examples and hallucinated APIs.
+**Dependencies**: Automated updates via Renovate. Keep `pnpm-lock.yaml` synced with `package.json`.
 
-#### Configuration
-
-Context7 MCP is configured for this project:
-
-- Local server: `claude mcp list` shows `context7: npx -y @upstash/context7-mcp@latest`
-- Project config: `.mcp.json` contains Context7 server definition
-
-#### Usage Examples
-
-**Basic Usage:**
-
-```
-How do I implement server components in Next.js 15? use context7
-```
-
-**With uc7 Shortcut:**
-
-```
-uc7 - Create a React component with Tailwind CSS using latest best practices
-```
-
-**Framework-Specific Queries:**
-
-```
-Show me the latest Vite configuration options for React. use context7
-What are the new features in TypeScript 5.8? use context7
-How to use Turborepo with Next.js app router? use context7
-```
-
-#### Best Practices
-
-1. **Always include "use context7"** for technical documentation queries
-2. **Be specific about versions** when asking about framework features
-3. **Use with `uc7` shortcut** for comprehensive, up-to-date solutions
-4. **Combine with current year** (2025) in searches for latest information
-
-### Dependency Management
-
-- **Renovate**: Automated dependency updates via GitHub App
-- **Dependency Dashboard**: View all pending updates in GitHub Issues
-- **Security Updates**: Automatically prioritized and labeled
-- **Monorepo Grouping**: Dependencies grouped by package and ecosystem
-- **Major Updates**: Require manual approval via Dependency Dashboard
-- **Schedule**: Monday mornings (4am EST) to minimize disruption
-
-### Lockfile Management
-
-**IMPORTANT**: Always keep `pnpm-lock.yaml` in sync with `package.json` to avoid CI failures.
-
-#### When to Update Lockfile
-
-1. **After modifying package.json**: Any changes to dependencies, devDependencies, or scripts
-2. **After merging PRs**: If conflicts occurred in package.json
-3. **When CI fails**: With "ERR_PNPM_OUTDATED_LOCKFILE" error
-
-#### How to Update Lockfile
-
-```bash
-# Update lockfile without installing packages
-pnpm install --lockfile-only
-
-# Verify and commit
-git add pnpm-lock.yaml
-git commit -m "fix: update pnpm-lock.yaml to match package.json"
-```
-
-#### Automated Safeguards
-
-1. **Pre-push hook**: Validates lockfile before pushing (via Lefthook)
-2. **CI validation**: All workflows use `--frozen-lockfile` to catch issues
-3. **Dependency check**: `pnpm audit` runs in dependency-review workflow
-
-#### Common Issues
-
-- **Merge conflicts in lockfile**: Delete lockfile, run `pnpm install`, commit new lockfile
-- **Renovate conflicts**: Let Renovate recreate its lockfile updates after merging
-- **Version drift**: Ensure all environments use pnpm v10.12.1
-
-### Documentation Standards - STRICTLY ENFORCED
-
-**CRITICAL**: All documentation MUST follow Diátaxis framework. Non-compliance blocks PRs.
-
-#### Diátaxis Framework (MANDATORY)
-
-Every documentation file MUST be categorized as ONE of these types:
-
-1. **TUTORIAL** (Learning-oriented): "Build Your First CLI App"
-   - Step-by-step learning experience
-   - Complete working project outcome
-   - NO options or alternatives
-   - For beginners learning concepts
-
-2. **HOW-TO** (Task-oriented): "How to Add Custom Validation"
-   - Solve specific user problems
-   - Assumes existing knowledge
-   - Multiple approaches OK
-   - For users with goals
-
-3. **REFERENCE** (Information-oriented): "API Reference"
-   - Comprehensive technical specs
-   - NO instructions or tutorials
-   - Consistent structure
-   - For lookup/verification
-
-4. **EXPLANATION** (Understanding-oriented): "Why We Use Result Types"
-   - Conceptual understanding
-   - Design decisions and trade-offs
-   - Background context
-   - For deeper comprehension
-
-#### Strict Requirements
-
-**EVERY documentation file MUST:**
-
-- Include correct frontmatter with `type` field
-- Match content to declared type (mixed content = REJECTED)
-- Follow templates in `docs/templates/`
-- Pass automated validation (`pnpm docs:validate`)
-
-**FORBIDDEN patterns:**
-
-- ❌ Tutorials with multiple solution paths
-- ❌ How-to guides explaining concepts
-- ❌ Reference docs with instructions
-- ❌ Explanations with step-by-step tasks
-- ❌ Mixed content types in single file
-
-#### Templates (REQUIRED)
-
-Use these templates for new documentation:
-
-- `docs/templates/tutorial-template.md`
-- `docs/templates/howto-template.md`
-- `docs/templates/reference-template.md`
-- `docs/templates/explanation-template.md`
-
-#### Quality Gates
-
-Documentation changes are BLOCKED if:
-
-- No frontmatter with correct `type`
-- Content doesn't match declared type
-- Fails Vale or markdownlint checks
-- Missing from required categories
-- Violates Diátaxis principles
-
-#### Commands
-
-```bash
-pnpm docs:validate    # Check all documentation
-pnpm docs:lint       # Style and format checks
-pnpm docs:new        # Create from templates
-```
-
-**Resources:**
-
-- [Full Standards](docs/DOCUMENTATION_STANDARDS.md)
-- [Review Checklist](docs/DOCUMENTATION_REVIEW_CHECKLIST.md)
-- [Quick Reference](docs/WRITING_DOCUMENTATION.md)
-
-**No exceptions.** Documentation quality is non-negotiable.
+**Documentation**: Follow [Diátaxis framework](docs/README.md). See [documentation standards](docs/reference/documentation-standards.md) for complete guidelines.
 
 ## Monorepo Overview
 
@@ -583,117 +413,17 @@ pnpm build                  # Production build
 
 ## Shortcuts Reference
 
-### General Shortcuts
+### Essential Shortcuts
 
-- `uc7` = [use Context7] Apply these principles: Deep analysis, exhaustive coverage, functional patterns, type safety, DRY, YAGNI, KISS, files should be organized logically and "do one thing well" and high-ROI testing approach if explicitly asked to add testing. Research current best practices and provide comprehensive solution using **Context7 MCP for up-to-date documentation** (add "use context7" to queries). Do not commit unless explicitly stated.
-- `askq` = Ask clarifying questions to understand requirements, constraints, and expected outcomes. Focus on ambiguous requirements, missing context, edge cases, and technical constraints that would impact the solution.
-- `qc` = Quality check in 3 passes: 1) Did I miss anything from the requirements? 2) Can this solution be improved (performance, readability, maintainability)? 3) Does it follow all project principles (DRY, YAGNI, KISS, functional patterns, type safety)?
-- `qcu` = Ultra-deep quality check: 1) Requirements audit - missed any stated/implied requirements, edge cases, error handling, accessibility, performance? 2) Security review - auth, validation, data exposure, OWASP top 10? 3) Architecture impact - system fit, scalability, tech debt, migration paths? 4) Future-proofing - assumptions, breakage points, extensibility? 5) Code excellence - elegant, self-documenting, follows all principles? 6) Hidden complexities - race conditions, memory leaks, performance cliffs, state issues? 7) Testing gaps - untested areas, integration points, failure/recovery scenarios?
-- `explain` = Explain this code/error/concept in simple terms with concrete examples
-- `refactor` = Suggest refactoring improvements focusing on readability, performance, and maintainability
-- `edge-cases` = Identify edge cases, error scenarios, and potential bugs in this implementation
-- `alt` = Provide alternative approaches with pros/cons for each
-- `fix-this` = Debug this issue systematically: reproduce → isolate → fix → verify
-- `todo-plan` = Create a detailed implementation plan with TodoWrite before starting
-- `quick` = Give me the most direct solution without explanation (for simple tasks)
-- `code-review` = Code review this as if you're a senior engineer: security, performance, best practices
-- `write-tests` = Write high-ROI tests for this code following project principles
-- `clean-code` = Deep clean codebase: 1) Remove ALL backwards compatibility code (this is v1.0, no legacy support needed), 2) Delete unused files, functions, variables, imports, exports, 3) Remove low-ROI tests (rendering, prop forwarding, snapshots), 4) Delete obsolete documentation, 5) Remove commented-out code, 6) Eliminate dead code paths and unreachable conditions, 7) Remove unnecessary dependencies, 8) Delete example/bothedemo files that aren't actively used. Be aggressive - if it's not actively used, it goes. Use git history if needed later.
-- `fixlint` = Fix all TypeScript errors and lint warnings. Remove unused imports, prefix
-  unused variables with underscore, fix type errors, and ensure code passes all static
-  analysis checks.
-- `gcwm` = Fix all lint and ts errors and warnings (fixlint). Git commit with meaningful message. Break changes into atomic commits: one logical change per commit. Each commit should be independently revertable. Use conventional commit format when applicable (feat:, fix:, refactor:, etc.). Focus on "why" not "what" in messages.
-- `gpr` = GitHub pull request: 1) Ensure branch is up-to-date with main (git fetch origin && git rebase origin/main), 2) Create PR with title from commits, 3) Run validation checks, 4) Assign reviewers based on changed files, and auto-link issues. Detects affected packages in monorepo.
-- `gbcp` = Git branch, commit, push/PR workflow: 1) Create new feature branch from current branch, 2) Stage all changes and commit with meaningful message (gcwm), including "Closes #[issue-number]" or "Fixes #[issue-number]" in commit message if working on a GitHub issue, 3) Push branch and create PR with auto-generated description (gpr), ensuring PR description includes "Closes #[issue-number]" to auto-link and close the issue when merged.
-- `sync-main` = Sync branch with main using rebase strategy: 1) git fetch origin, 2) git rebase origin/main, 3) resolve conflicts if needed.
-- `check-sync` = Check if current branch is up-to-date with main without pulling. Uses @esteban-url/trailhead-cli/git utilities.
-- `pub` = Publish packages with Changesets: 1) Check release status with `pnpm changeset:status`, 2) If no changeset exists, create one with `pnpm changeset:add`, 3) Push changes to trigger automated release via GitHub Action, 4) The automation handles version bumping, changelog generation, and publishing. For manual release: `pnpm version-packages` then `pnpm release`.
-- `pubdr` = Publish dry-run: Check what would be published without actually releasing. Runs `pnpm release:dry-run` to preview package contents and verify everything looks correct before actual publish. Use before `pub` to ensure safety.
-- `reality-check` = STOP. Is this actually needed? Ask: Who requested this? What specific problem does it solve? Can existing tools handle this? Will 80%+ of users need this? Be brutally honest about whether this adds value or just complexity.
-- `yagni-audit` = Review current implementation for YAGNI violations. Identify features, abstractions, configurations, or optimizations that aren't used by real users. Recommend removal.
-- `user-first` = Refocus on actual user needs. What do users actually want to accomplish? What's the simplest way to achieve that? Ignore "best practices" that don't serve real user goals.
-- `scope-check` = Verify single responsibility. Does this issue/PR address exactly one problem? Are we trying to do too much? Should this be split into separate issues?
-- `branch-audit` = Check branch structure. Are we working from main? Is this a branch-on-branch (red flag)? Does branch name match issue scope?
-- `gh-issue` = Comprehensive GitHub issue analysis and implementation planning: 1) Fetch issue details with `gh issue view [number] --comments` to get full conversation history, 2) Analyze ALL comments for additional context, requirements changes, design decisions, and implementation hints, 3) Create feature branch from main with semantic naming (feat/fix/refactor-issue-number-brief-description), 4) IMMEDIATELY checkout the new branch to ensure all work happens in the feature branch and main remains clean. 5) Deep codebase examination using search tools to identify: existing partial implementations, related code patterns, similar features, affected dependencies, and architectural constraints, 6) Apply core principles analysis: functional patterns, type safety, DRY violations to avoid, YAGNI considerations, and high-ROI testing approach, 7) Cross-reference with related issues/PRs using `gh issue list` and `gh pr list` for context, 8) Identify monorepo impact across all packages and apps, 9) Create comprehensive TodoWrite plan with: problem analysis summary, codebase findings, implementation strategy aligned with principles, specific atomic tasks, testing approach, and affected package considerations.
-
-### Documentation Shortcuts
-
-- `write-docs` = Write comprehensive documentation with: clear overview, usage examples, API reference, edge cases, and common pitfalls
-- `docstring` = Add inline documentation (JSDoc/docstrings) with parameters, return values, examples, and throws
-- `readme` = Create/update README with: project overview, installation, usage, API, examples, contributing guidelines
-- `api` = Document API endpoints/functions with: description, parameters, return types, error codes, examples
-- `changelog` = Update CHANGELOG following Keep a Changelog format: Added, Changed, Deprecated, Removed, Fixed, Security
-- `example` = Create practical, runnable examples demonstrating common use cases
-- `migration` = Write migration guide with: breaking changes, upgrade steps, before/after code examples
-- `troubleshoot` = Document common issues with: symptoms, causes, solutions, and prevention
-- `architecture` = Document system architecture with: components, data flow, design decisions, trade-offs
-- `comment` = Add helpful inline comments explaining "why" not "what" for complex logic
-- `tutorial` = Create step-by-step tutorial with prerequisites, goals, and progressive complexity
-- `faq` = Generate FAQ from common issues, gotchas, and best practices
-
-### /compact Shortcuts
-
-- `compact` = Maximum brevity. Answer in 1-3 lines. No explanations unless asked.
-- `tldr` = Give me just the answer/solution, nothing else
-- `cli` = Respond like a CLI tool - minimal output, no pleasantries
-- `brief` = Short answer with only essential context (under 5 lines)
-- `expand` = Give me the detailed explanation (opposite of compact)
-- `yes/no` = Binary answer only, no elaboration
-- `list` = Bullet points only, no prose
-- `code-only` = Just show code, no explanation
-- `one-line` = Compress answer to single line
-- `verbose` = Full explanation with examples and context (when you need details)
-
-## Assertive Response Templates for Over-Engineering
-
-**When user requests over-engineered features, Claude MUST respond:**
-
-### Template 1: Complexity Challenge
-
-```
-This appears to be over-engineering. Most users need [simple alternative].
-
-The proposed solution adds [specific complexity] without clear user benefit.
-
-Suggested approach: [simpler solution]
-
-If you have specific requirements that justify this complexity, please explain the user problem this solves.
-```
-
-### Template 2: Reality Check Response
-
-```
-REALITY CHECK:
-- Who specifically requested this feature?
-- What user problem does this solve today?
-- Can existing tools handle this?
-- Will 80%+ of users need this?
-
-Based on these questions, I recommend [simpler alternative] instead.
-```
-
-### Template 3: YAGNI Enforcement
-
-```
-This violates YAGNI (You Aren't Gonna Need It).
-
-Current approach creates unnecessary complexity for hypothetical future needs.
-
-Alternative: Start with [minimal solution]. Add complexity only when users specifically request it.
-```
-
-### Template 4: Branch Discipline Warning
-
-```
-Creating a branch from another branch is a RED FLAG indicating scope creep.
-
-This suggests we're trying to do more than originally planned.
-
-Recommended:
-1. Finish current branch and merge to main
-2. Create new branch from main for additional work
-3. Or reconsider if the additional work is actually needed
-```
+- `uc7` = Use Context7 for up-to-date documentation, best practices and research.
+- `askq` = Ask clarifying questions about requirements, constraints, edge cases, and technical constraints.
+- `qc` = Quality check: 1) Missing requirements? 2) Improvements possible? 3) Follows principles (DRY, YAGNI, KISS, functional patterns, type safety)?
+- `qcu` = Ultra-deep quality check: Requirements audit, security review, architecture impact, future-proofing, code excellence, hidden complexities, testing gaps.
+- `fixlint` = Fix all TypeScript errors and lint warnings. Remove unused imports, prefix unused variables with underscore.
+- `write-tests` = Write high-ROI tests following project principles (no low-ROI rendering/prop tests).
+- `gcwm` = Fix lint/TS errors. Git commit with meaningful message. Break changes into atomic commits: one logical change per commit. Each commit should be independently revertable. Use conventional commit format when applicable (feat:, fix:, refactor:, etc.). Focus on "why" not "what" in messages.
+- `gbcp` = Git branch, commit, push/PR workflow. Include "Closes #[issue]" in commit/PR for auto-linking.
+- `gh-issue` = Comprehensive GitHub issue analysis: fetch details and comments, create feature branch, deep codebase examination, apply principles, create TodoWrite plan.
 
 # important-instruction-reminders
 
@@ -702,4 +432,4 @@ NEVER create files unless they're absolutely necessary for achieving your goal.
 ALWAYS prefer editing an existing file to creating a new one.
 NEVER proactively create documentation files (\*.md) or README files. Only create documentation files if explicitly requested by the User.
 
-**MOST IMPORTANT**: Claude MUST actively resist over-engineering requests using the reality check framework and assertive response templates above. Prevention of complexity is more valuable than removal of complexity.
+**MOST IMPORTANT**: Claude MUST actively resist over-engineering requests using the reality check framework. Prevention of complexity is more valuable than removal of complexity.


### PR DESCRIPTION
- Remove 20+ unused shortcuts with no commit evidence
- Fix Context7 section by removing misleading usage examples
- Replace detailed dependency/documentation sections with external references
- Merge redundant principle sections into concise format
- Reduce from 706 to 442 lines (37% reduction)

Keeps only 9 essential shortcuts with proven usage while maintaining all necessary information through external documentation links.
