### PR TITLE
chore: update pnpm to 10.12.4

### DIFF
--- a/.github/CI_OPTIMIZATIONS.md
+++ b/.github/CI_OPTIMIZATIONS.md
@@ -131,7 +131,7 @@ pnpm lint types test --filter=@esteban-url/trailhead-web-ui
 ```yaml
 env:
   NODE_VERSION: 20.11.0
-  PNPM_VERSION: 10.12.1
+  PNPM_VERSION: 10.12.4
   FORCE_COLOR: 3
   CI: true
   # Turborepo Remote Cache

--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -9,7 +9,7 @@ inputs:
   pnpm-version:
     description: 'pnpm version to use'
     required: false
-    default: '10.12.1'
+    default: '10.12.4'
   install-deps:
     description: 'Whether to install dependencies'
     required: false

--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -8,7 +8,7 @@ inputs:
   pnpm-version:
     description: 'pnpm version to use'
     required: false
-    default: '10.12.1'
+    default: '10.12.4'
 
 runs:
   using: 'composite'

--- a/docs/how-to/contributing.md
+++ b/docs/how-to/contributing.md
@@ -28,7 +28,7 @@ Thank you for contributing to the Trailhead monorepo! This guide covers the deve
 
    The monorepo uses different PNPM versions:
    - **Root**: PNPM 8.15.0 (specified in root package.json)
-   - **@esteban-url/trailhead-web-ui**: PNPM 10.12.1 (specified in its package.json)
+   - **@esteban-url/trailhead-web-ui**: PNPM 10.12.4 (specified in its package.json)
 
    This is intentional to support different feature requirements. The root version manages the monorepo infrastructure while individual packages can specify their own versions for optimal compatibility.
 
@@ -39,6 +39,7 @@ Thank you for contributing to the Trailhead monorepo! This guide covers the deve
    ```
 
 4. **Build**
+
    ```bash
    pnpm build
    ```

--- a/packages/create-trailhead-cli/templates/shared/package.json.hbs
+++ b/packages/create-trailhead-cli/templates/shared/package.json.hbs
@@ -67,7 +67,7 @@
     "node": ">=18.0.0"{{#if (eq packageManager "pnpm")}},
     "pnpm": ">=8.0.0"{{/if}}
   },{{#if (eq packageManager "pnpm")}}
-  "packageManager": "pnpm@10.12.1",{{/if}}
+  "packageManager": "pnpm@10.12.4",{{/if}}
   "sideEffects": false,
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- Updates PNPM version from 10.12.1 to 10.12.4 across CI actions, documentation, and package templates
- Ensures consistency across GitHub Actions workflows and package generation

## Changes
- Updated `.github/CI_OPTIMIZATIONS.md` PNPM version reference
- Updated `.github/actions/setup-monorepo/action.yml` default PNPM version
- Updated `.github/actions/setup-node-pnpm/action.yml` default PNPM version  
- Updated `docs/how-to/contributing.md` PNPM version documentation
- Updated `packages/create-trailhead-cli/templates/shared/package.json.hbs` package manager specification

## Test plan
- [x] CI workflows will use updated PNPM version
- [x] Documentation reflects current PNPM version
- [x] New projects created with CLI will use updated PNPM version