### PR TITLE
fix(ci): correct CLI path in pre-release workflow

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -128,7 +128,7 @@ jobs:
         shell: bash
         run: |
           cd packages/cli
-          node dist/src/index.js --help
+          node dist/index.js --help
           echo "✅ CLI works on ${{ matrix.os }} with Node ${{ matrix.node }}"
 
       - name: Test generator
@@ -224,7 +224,7 @@ jobs:
           # Measure CLI startup time
           echo "Testing CLI startup performance..."
           START=$(date +%s%N)
-          node dist/src/index.js --help >/dev/null 2>&1
+          node dist/index.js --help >/dev/null 2>&1
           END=$(date +%s%N)
           STARTUP_TIME=$(( (END - START) / 1000000 ))
           echo "CLI startup time: ${STARTUP_TIME}ms"


### PR DESCRIPTION
## Summary

Fixes MODULE_NOT_FOUND errors in Tier 2 - Pre-Release Comprehensive Validation workflow.

## Key Changes

• **Fix CLI path** - Change `dist/src/index.js` to `dist/index.js` in pre-release.yml
• **CLI functionality test** - Correct path for cross-platform testing 
• **Performance benchmark** - Fix CLI startup time measurement path

## Issue Resolution

The build output is at `dist/index.js`, not `dist/src/index.js`. This was causing all CLI Matrix tests to fail with:
```
Error: Cannot find module '/path/to/packages/cli/dist/src/index.js'
```

## Testing Validation

✅ Build output confirmed at correct path
✅ Package.json main entry points to `dist/index.js`
✅ Fix applied to both test steps in workflow

Resolves the failing comprehensive validation checks.