### PR TITLE
fix(cli): handle cross-platform path formats in integration test

### DIFF
--- a/packages/cli/src/testing/integration.test.ts
+++ b/packages/cli/src/testing/integration.test.ts
@@ -92,7 +92,18 @@ describe('Cross-Package Testing Composition', () => {
 
     // 4. Verify complete workflow
     const allFiles = mockFs.getAllFiles()
-    expect(Object.keys(allFiles)).toContain('/workspace/package.json')
-    expect(Object.keys(allFiles)).toContain('/workspace/src/index.ts')
+    const filePaths = Object.keys(allFiles)
+
+    // Normalize paths to handle both Unix and Windows formats
+    // On Windows, paths may have backslashes and drive letters
+    const hasPackageJson = filePaths.some((path) =>
+      path.replace(/\\/g, '/').endsWith('/workspace/package.json')
+    )
+    const hasIndexTs = filePaths.some((path) =>
+      path.replace(/\\/g, '/').endsWith('/workspace/src/index.ts')
+    )
+
+    expect(hasPackageJson).toBe(true)
+    expect(hasIndexTs).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- Fixed Windows CI test failure in integration test
- Handles cross-platform path format differences (Unix vs Windows)

## Problem
The test was failing on Windows CI because `getAllFiles()` returns paths with OS-specific separators:
- Unix: `/workspace/package.json`
- Windows: `\D:\workspace\package.json`

## Solution
- Normalize paths by replacing backslashes with forward slashes
- Use `.endsWith()` check instead of exact match to handle drive letters
- This allows the test to work on both Unix and Windows systems

## Test Plan
- [x] Local tests pass on macOS
- [ ] Windows CI should now pass (will verify in PR checks)

## Related Issues
This is a follow-up to the module resolution fixes, addressing the remaining test failure on Windows.