### PR TITLE
fix(ci): remove non-existent packages from changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,7 @@
   ],
   "commit": false,
   "fixed": [],
-  "linked": [["@esteban-url/trailhead-cli", "@esteban-url/trailhead-web-ui"]],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
## Summary
- Fixes release CI validation errors by removing references to non-existent packages
- Removes @esteban-url/trailhead-cli and @esteban-url/trailhead-web-ui from linked array

## Problem
The release CI was failing with changeset validation errors because the config referenced packages that don't exist in the monorepo.

## Solution
Removed the incorrect package names from the linked array in .changeset/config.json.

## Testing
- Verified all actual package names in the monorepo
- Build passes locally after fix