### PR TITLE
fix(ci): move CodeQL analysis from PR to main branch workflow

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -49,6 +49,25 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         continue-on-error: true
 
+  # CodeQL Analysis (only on main)
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+      
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+
   # Cross-platform smoke test (only on main)
   compatibility:
     name: OS Compatibility

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -38,15 +38,3 @@ jobs:
           # Run ALL tests to ensure nothing is broken
           pnpm turbo run test
       
-      # Things that are hard to run locally
-      - name: Initialize CodeQL
-        if: github.event_name == 'pull_request'
-        uses: github/codeql-action/init@v3
-        with:
-          languages: javascript-typescript
-        continue-on-error: true
-      
-      - name: CodeQL Analysis
-        if: github.event_name == 'pull_request'
-        uses: github/codeql-action/analyze@v3
-        continue-on-error: true


### PR DESCRIPTION
## Summary
- Moves CodeQL analysis from PR workflow to main branch workflow
- Reduces CI time and costs for PRs
- Maintains security scanning on merged code

## Rationale
CodeQL analysis is primarily for security monitoring rather than PR validation. Running it on every PR adds unnecessary time and cost. Moving it to the main branch workflow ensures security scanning still happens on merged code while making PR checks faster.

## Changes
- Removed CodeQL steps from .github/workflows/ci-pr.yml
- Added dedicated CodeQL job to .github/workflows/ci-main.yml
- Configured proper permissions for security events writing