### PR TITLE
fix(ci): configure GitHub Packages publishing properly

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -34,13 +34,19 @@ jobs:
         run: pnpm install --frozen-lockfile
       
       - name: Build packages
-        run: pnpm turbo run build
+        run: pnpm turbo run build --force
       
       # Only on main: publish, security scan, cross-platform
       - name: Publish to GitHub Packages
         if: startsWith(github.event.head_commit.message, 'feat') || startsWith(github.event.head_commit.message, 'fix')
-        run: pnpm changeset publish
+        run: |
+          # Configure npm auth for GitHub Packages
+          npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
+          
+          # Run changeset publish
+          pnpm changeset publish
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Security Scan

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -6,7 +6,7 @@
   "description": "Focused CLI framework orchestrator for building production-ready command-line applications with TypeScript and Result types",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -6,7 +6,7 @@
   "private": false,
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "exports": {
     ".": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "description": "Foundation package for Trailhead System - CoreError interface, Result types, and functional programming utilities",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/create-cli/package.json
+++ b/packages/create-cli/package.json
@@ -6,7 +6,7 @@
   "description": "CLI generator for creating projects with @esteban-url/cli",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "bin": {
     "create-cli": "./bin/cli.js",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -6,7 +6,7 @@
   "description": "Unified data processing and format detection (CSV, JSON, Excel) with Result types for Trailhead System",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/fs/package.json
+++ b/packages/fs/package.json
@@ -6,7 +6,7 @@
   "description": "Functional filesystem operations with Result types for Trailhead System",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/sort/package.json
+++ b/packages/sort/package.json
@@ -64,6 +64,7 @@
     "pnpm": ">=8.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -6,7 +6,7 @@
   "description": "Functional validation with Zod integration and Result types for Trailhead System",
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.pkg.github.com"
   },
   "types": "./dist/index.d.ts",
   "exports": {

--- a/tooling/tsup-config/package.json
+++ b/tooling/tsup-config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@repo/tsup-config",
   "version": "1.0.0",
+  "private": true,
   "description": "Shared tsup configuration for the Trailhead monorepo",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
- Configure packages to publish to GitHub Packages instead of npm
- Fix CI authentication and build issues

## Changes
- Mark @repo/tsup-config as private to prevent npm publish attempts
- Update all packages to use GitHub Packages registry endpoint
- Force build in CI to ensure all declaration files are generated
- Configure npm authentication properly before publishing

## Test Plan
- CI will run automatically and validate the changes
- Publishing will be tested when a feat/fix commit is merged