### PR TITLE
fix(ci): remove duplicate --force flag in turbo build command

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       
       - name: Build packages
-        run: pnpm turbo run build --force --force
+        run: pnpm turbo run build --force
       
       # Only on main: publish, security scan, cross-platform
       - name: Publish to GitHub Packages


### PR DESCRIPTION
## Summary
Fixes CI build error caused by duplicate --force flag

## Problem
The CI was failing with:
```
ERROR the argument '--force [<FORCE>]' cannot be used multiple times
```

## Solution
Changed from `pnpm turbo run build --force --force` to `pnpm turbo run build --force`

## Test Plan
CI will validate this change automatically