### PR TITLE
revert(ci): remove build artifact sharing between jobs

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -9,56 +9,9 @@ env:
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 jobs:
-  # Build once and share artifacts
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - uses: pnpm/action-setup@v4
-      
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-      
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      
-      - name: Build all packages
-        run: pnpm turbo run build --force
-      
-      # Upload build artifacts for other jobs
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build-artifacts
-          path: |
-            packages/*/dist
-            apps/*/dist
-            apps/*/.next
-            tooling/*/dist
-          retention-days: 1
-      
-      # Also upload node_modules for faster installs in other jobs
-      - name: Upload dependencies
-        uses: actions/upload-artifact@v4
-        with:
-          name: node-modules
-          path: |
-            node_modules
-            packages/*/node_modules
-            apps/*/node_modules
-            tooling/*/node_modules
-          retention-days: 1
-
-  # Release job depends on build
+  # Things that MUST run in GitHub
   release:
     name: Release
-    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -68,38 +21,34 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - uses: pnpm/action-setup@v4
-      
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
           registry-url: 'https://npm.pkg.github.com'
-      
-      # Download pre-built artifacts
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts
-      
-      - name: Download dependencies
-        uses: actions/download-artifact@v4
-        with:
-          name: node-modules
-      
-      # Only on main: publish, security scan
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm turbo run build --force
+
+      # Only on main: publish, security scan, cross-platform
       - name: Publish to GitHub Packages
         if: startsWith(github.event.head_commit.message, 'feat') || startsWith(github.event.head_commit.message, 'fix')
         run: |
           # Configure npm auth for GitHub Packages
           npm config set //npm.pkg.github.com/:_authToken ${{ secrets.GITHUB_TOKEN }}
-          
+
           # Run changeset publish
           pnpm changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Security Scan
         uses: snyk/actions/node@master
         env:
@@ -117,19 +66,18 @@ jobs:
   #     security-events: write
   #   steps:
   #     - uses: actions/checkout@v4
-  #     
+  #
   #     - name: Initialize CodeQL
   #       uses: github/codeql-action/init@v3
   #       with:
   #         languages: javascript-typescript
-  #     
+  #
   #     - name: Perform CodeQL Analysis
   #       uses: github/codeql-action/analyze@v3
 
-  # Cross-platform smoke test depends on build
+  # Cross-platform smoke test (only on main)
   compatibility:
     name: OS Compatibility
-    needs: build
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
@@ -140,17 +88,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      
-      # Download pre-built CLI package
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts
-      
-      # Install only runtime dependencies (dev deps not needed for smoke test)
-      - name: Install runtime dependencies
-        run: pnpm install --frozen-lockfile --prod
-      
-      # Run smoke test on pre-built CLI
-      - name: Smoke test
-        run: pnpm --filter=@esteban-url/cli run test -- --run
+          cache: 'pnpm'
+
+      - name: Install and smoke test
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm turbo run build --filter=@esteban-url/cli
+          pnpm --filter=@esteban-url/cli run test -- --run


### PR DESCRIPTION
## Summary
Reverts the build artifact sharing implementation that was causing CI failures.

## Changes
- Remove build artifact uploads/downloads from CI workflow
- Restore independent builds for test and publish jobs
- Fix CI reliability issues

## Context
The artifact sharing approach introduced in #177 led to consistent CI failures. This revert restores the previous working configuration where each job builds independently.

Closes #178